### PR TITLE
The BinarySearch did not consider the boundary problem, resulting in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ public class Main {
 
             System.out.println(Arrays.toString(baseStation.find("8.8.8.8")));
             System.out.println(Arrays.toString(baseStation.find("223.221.121.0")));
+            
+            // store2csv
+            String csvPath = "/path/save/IpTemp.csv";
+            city.checkAndStore2CSV(csvPath);
 
         } catch (IOException ioex) {
             ioex.printStackTrace();

--- a/datx/src/net/ipip/datx/City.java
+++ b/datx/src/net/ipip/datx/City.java
@@ -66,4 +66,78 @@ public class City
 
         return null;
     }
+
+    /**
+     * Save .mmdb to .csv file
+     * CSV file format to "start_address,end_address,country,region,city", eg. 1.2.8.0,1.2.8.255,中国,北京,北京
+     *
+     * @param csvPath
+     * @throws Exception
+     */
+    public void checkAndStore2CSV(String csvPath) throws Exception {
+
+        FileWriter fw = new FileWriter(new File(csvPath));
+        HashSet<String> dedup = new HashSet<String>();
+        String header = "start_address,end_address,country,region,city\n";
+        dedup.add(header);
+        fw.write(header);
+
+        int start = 262148;
+        int low = 0;
+        int high = new Long((indexSize - 262144 - 262148) / 9).intValue() - 1;
+        int pos = 0;
+        while (low++ < high) {
+            pos = low * 9;
+            int pos1 = pos;
+            if (low > 0) {
+                pos1 = (low - 1) * 9;
+            }
+            long ipLongBegin = Util.bytesToLong(data[start + pos1], data[start + pos1 + 1], data[start + pos1 + 2], data[start + pos1 + 3]);
+
+            long ipLongEnd = Util.bytesToLong(data[start + pos], data[start + pos + 1], data[start + pos + 2], data[start + pos + 3]);
+
+            byte b = 0;
+            long off = Util.bytesToLong(b, data[start + pos + 6], data[start + pos + 5], data[start + pos + 4]);
+            long len = Util.bytesToLong(b, b, data[start + pos + 7], data[start + pos + 8]);
+            int offset = new Long(off - 262144 + indexSize).intValue();
+            byte[] loc = Arrays.copyOfRange(data, offset, offset + new Long(len).intValue());
+            String[] split = new String(loc, Charset.forName("UTF-8")).split("\t", -1);
+
+            String ipStringBegin = Util.ipLong2String(ipLongBegin);
+            String[] ipStrings = ipStringBegin.split("\\.");
+            int i = ipStrings.length - 1;
+            while (i >= 0) {
+                int intValue = Integer.parseInt(ipStrings[i]);
+                int res = (intValue + 1) % 256;
+                ipStrings[i] = res + "";
+                if (res != 0) {
+                    break;
+                }
+                i--;
+            }
+            ipStringBegin = ipStrings[0] + "." + ipStrings[1] + "." + ipStrings[2] + "." + ipStrings[3];
+            String ipStringEnd = Util.ipLong2String(ipLongEnd);
+
+            String[] checkStart = find(ipStringBegin);
+            String[] checkEnd = find(ipStringEnd);
+
+            String startString = checkStart[0] + "," + checkStart[1] + "," + checkStart[2];
+            String endString = checkEnd[0] + "," + checkEnd[1] + "," + checkEnd[2];
+            String saveString = split[0] + "," + split[1] + "," + split[2];
+            if (!(startString.equals(endString) && endString.equals(saveString))) {
+                    throw new Exception("Datx file parse to csv error! Different with start_address and end_address. Start_address: '"
+                            + startString + "', End_address: '" + endString + "'");
+            }
+
+            String ret = String.format("%s,%s,%s,%s,%s\n", ipStringBegin, ipStringEnd, split[0], split[1], split[2]);
+            if (dedup.contains(ret)) {
+                System.out.println("Create datx2CSV success.");
+                fw.close();
+                return;
+            } else {
+                dedup.add(ret);
+                fw.write(ret);
+            }
+        }
+    }
  }

--- a/datx/src/net/ipip/datx/City.java
+++ b/datx/src/net/ipip/datx/City.java
@@ -48,7 +48,7 @@ public class City
             long end = Util.bytesToLong(data[start + pos], data[start + pos+1], data[start + pos+2], data[start + pos+3]);
             if (val > end) {
                 low = mid + 1;
-            } else if (val < s) {
+            } else if (val <= s) {
                 high = mid - 1;
             } else {
 

--- a/datx/src/net/ipip/datx/Util.java
+++ b/datx/src/net/ipip/datx/Util.java
@@ -51,4 +51,15 @@ public class Util {
         }
         return l;
     }
+
+    public static String ipLong2String(long ipLong) {
+        int a = ((int) ipLong) >> 24;
+        if (a < 0) {
+            a = (a & 0x7F) + 128;
+        }
+        long b = ((int) ipLong & 0x00FFFFFF) >> 16;
+        long c = ((int) ipLong & 0x0000FFFF) >> 8;
+        long d = ((int) ipLong & 0x000000FF);
+        return a + "." + b + "." + c + "." + d;
+    }
 }


### PR DESCRIPTION
…an error in the query.

![image](https://user-images.githubusercontent.com/44091568/57681470-5b2c1900-7662-11e9-975c-3026ffe18c8e.png)
通过find 方法查询边界值会有误差，与线上ipip.net 查询结果不一致，由二分查询导致，需要考虑边界问题。